### PR TITLE
Fix the crash caused by missing argument keys

### DIFF
--- a/controllers/broadcast.py
+++ b/controllers/broadcast.py
@@ -65,5 +65,5 @@ class AppBroadcastHandler(WebBaseHandler):
         alert = self.get_argument('notification').strip()
         sound = 'default'
         channel = 'default'
-        self.application.send_broadcast(self.appname, self.db, channel, alert)
+        self.application.send_broadcast(self.appname, self.db, channel=channel, alert=alert, sound=sound)
         self.render("app_broadcast.html", app=app, sent=True)


### PR DESCRIPTION
Test Plan:
1. Send a broadcast in app -> broadcast
2. It doesn't crash with below error any more:
TypeError: send_broadcast() takes exactly 3 arguments (5 given)
