### PR TITLE
Ensure we can add iOS params.

### DIFF
--- a/api/push.py
+++ b/api/push.py
@@ -115,6 +115,7 @@ class PushHandler(APIBaseHandler):
                 data.setdefault('apns', {})
                 data['apns'].setdefault('badge', data.get('badge', None))
                 data['apns'].setdefault('sound', data.get('sound', None))
+                data['apns'].setdefault('custom', data.get('custom', None))
                 self.get_apns_conn().process(token=self.token, alert=alert, extra=extra, apns=data['apns'])
                 self.send_response(ACCEPTED)
             elif device == DEVICE_TYPE_ANDROID:


### PR DESCRIPTION
Allows the ability to add custom parameters for iOS push notifications.

The only other way I found that was "native" was to include an apns parameter in my payload against the Airnotifier API; however then I would get errors in `build_payload` in `apns.py`

Whichever route you decide to go doesn't matter; but there is an issue. I don't have time to debug further if your intended purpose was to use the apns parameter in the API (Wouldn't know - there's no documentation...) - here's a quick patch if you don't either.

Cheers - thanks for your work.