### PR TITLE
Provide broadcast feedback from APNs

### DIFF
--- a/airnotifier.py
+++ b/airnotifier.py
@@ -68,6 +68,21 @@ class AirNotifierApp(tornado.web.Application):
         from routes import RouteLoader
         return RouteLoader.load(dir)
 
+    def get_broadcast_status(self, appname):
+	status = "Notification sent!"
+	error = False
+
+	try:
+	    apns = self.services['apns'][appname][0]
+	except (IndexError, KeyError):
+	    apns = None
+
+	if apns is not None and apns.hasError():
+	    status = apns.getError()
+	    error = True
+
+        return {'msg':status, 'error':error}
+
     def send_broadcast(self, appname, appdb, **kwargs):
         channel = kwargs.get('channel', 'default')
         alert   = kwargs.get('alert', None)

--- a/controllers/broadcast.py
+++ b/controllers/broadcast.py
@@ -48,3 +48,9 @@ class AppBroadcastHandler(WebBaseHandler):
         channel = 'default'
         self.application.send_broadcast(self.appname, self.db, channel=channel, alert=alert, sound=sound)
         self.render("app_broadcast.html", app=app, sent=True)
+
+@route(r"/applications/([^/]+)/broadcast/status")
+class AppBroadcastStatusHandler(WebBaseHandler):
+    @tornado.web.authenticated
+    def get(self, appname):
+        self.write(self.application.get_broadcast_status(appname))

--- a/pushservices/apns.py
+++ b/pushservices/apns.py
@@ -164,15 +164,6 @@ class APNClient(PushService):
         self.connected = False
         logging.warning('%s[%d] is offline %d' % (self.appname, self.instanceid, self.reconnect))
 
-        try:
-            self.remote_stream.close()
-            self.sock.close()
-            if self.reconnect:
-                self.connect()
-        except Exception, ex:
-            raise ex
-
-    def _on_remote_read_streaming(self, data):
         """ Something bad happened """
         status_table = {
                 0: "No erros",
@@ -215,6 +206,13 @@ class APNClient(PushService):
         (command, statuscode, identifier) = struct.unpack_from('!bbI', data, 0)
         logging.error('%s[%d] CMD: %s Status: %s ID: %s', self.appname, self.instanceid, command, status_table[statuscode], identifier)
 
+        try:
+            self.remote_stream.close()
+            self.sock.close()
+            if self.reconnect:
+                self.connect()
+        except Exception, ex:
+            raise ex
 
     def _on_remote_connected(self):
         self.connected = True
@@ -229,8 +227,8 @@ class APNClient(PushService):
         self.sock = socket(AF_INET, SOCK_STREAM)
         self.remote_stream = iostream.SSLIOStream(self.sock, ssl_options=dict(certfile=self.certfile, keyfile=self.keyfile))
         self.remote_stream.connect(self.apns, self._on_remote_connected)
-        self.remote_stream.read_until_close(self._on_remote_read_close,
-                                            self._on_remote_read_streaming)
+        self.remote_stream.read_until_close(self._on_remote_read_close)
+
     def shutdown(self):
         """Shutdown this connection"""
         self.reconnect = False

--- a/pushservices/apns.py
+++ b/pushservices/apns.py
@@ -147,6 +147,7 @@ class APNClient(PushService):
         self.keyfile = get_filepath(keyfile)
         self.messages = deque()
         self.reconnect = True
+	self.errors = None
         self.ioloop = ioloop.IOLoop.instance()
 
         self.appname = appname
@@ -205,6 +206,7 @@ class APNClient(PushService):
 
         (command, statuscode, identifier) = struct.unpack_from('!bbI', data, 0)
         logging.error('%s[%d] CMD: %s Status: %s ID: %s', self.appname, self.instanceid, command, status_table[statuscode], identifier)
+	self.errors = "%s (ID: %s)" % (status_table[statuscode], identifier)
 
         try:
             self.remote_stream.close()
@@ -289,7 +291,15 @@ class APNClient(PushService):
         return True
 
     def getQueueLength(self):
-        len(self.messages)
+        return len(self.messages)
+
+    def hasError(self):
+	return self.errors is not None
+
+    def getError(self):
+	temp = self.errors
+	self.errors = None
+	return temp
 
     def _send_message(self):
         if len(self.messages) and not self.remote_stream.closed():

--- a/templates/app_broadcast.html
+++ b/templates/app_broadcast.html
@@ -14,8 +14,27 @@
 
 {% block body %}
 {% if sent %}
-<div class="alert alert-success">
-    Notification sent!
+
+<script type="text/javascript">
+$(document).ready(function() {
+    $.ajax({url: window.location.pathname + "/status", type: "GET",
+        success: function(response) {
+	    if(response.error) {
+		$("#status").addClass("alert alert-danger");
+	    } else {
+	        $("#status").addClass("alert alert-success");
+	    }
+            $("#status").text(response.msg);
+        },
+        error: function(response) {
+	    $("#status").addClass("alert-danger");
+            $("#status").text("Error retrieving notification status!");
+        }
+    });
+});
+</script>
+
+<div id="status">
 </div>
 {% end %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" href="{{ static_url("css/bootstrap.min.css") }}" type="text/css"/>
     <link rel="stylesheet" href="{{ static_url("css/dashboard.css") }}" type="text/css"/>
     <link rel="shortcut icon" href="{{ static_url("favicon.ico") }}" type="image/x-icon">
+    <script src="{{ static_url("js/jquery-1.11.0.min.js") }}"></script>
+    <script src="{{ static_url("js/bootstrap.min.js") }}"></script>
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
       <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -64,7 +66,5 @@
         </p>
       </footer>
     </div><!--/.fluid-container-->
-    <script src="{{ static_url("js/jquery-1.11.0.min.js") }}"></script>
-    <script src="{{ static_url("js/bootstrap.min.js") }}"></script>
     </body>
 </html>


### PR DESCRIPTION
I initially started registering APNs tokens in sandbox mode, but when I switched to production mode, those tokens were still in the system.  So airnotifier was trying to send production notifications to sandbox device tokens, which did not succeed.  However, I couldn't tell that it succeeded because all that was posted was a green "Notification sent!" alert, which implied success.

This change allows APNs (for starters) to send broadcast status information back to the broadcast page so the user knows if an unexpected failure was encountered.

Also includes a change to log these events.