### PR TITLE
Add support for content-available APNs flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ airnotifier.conf
 logging.ini
 *.pyc
 .idea
+nohup.out
+airnotifier.err
+airnotifier.log
+

--- a/api/push.py
+++ b/api/push.py
@@ -122,6 +122,7 @@ class PushHandler(APIBaseHandler):
                 data.setdefault('apns', {})
                 data['apns'].setdefault('badge', data.get('badge', None))
                 data['apns'].setdefault('sound', data.get('sound', None))
+                data['apns'].setdefault('content', data.get('content', None))
                 data['apns'].setdefault('custom', data.get('custom', None))
                 self.get_apns_conn().process(token=self.token, alert=alert, extra=extra, apns=data['apns'])
                 self.send_response(ACCEPTED)

--- a/templates/base.html
+++ b/templates/base.html
@@ -62,9 +62,7 @@
         <p>
             <a target="_blank" href="http://airnotifier.github.io">AirNotifier</a>
             <span> | </span>
-            <a target="_blank" href="https://github.com/airnotifier/airnotifier">Github</a>
-            <span> | </span>
-            <a target="_blank" href="https://gitter.im/airnotifier/airnotifier">Community</a>
+            <a target="_blank" href="https://github.com/airnotifier/airnotifier">Development</a>
             <span> | </span>
             <a target="_blank" href="https://github.com/airnotifier/airnotifier/issues">Get support</a>
         </p>


### PR DESCRIPTION
This is code for #150 "Feature request: silent notifications": specifically, support for the APNs (iOS) "content-available" flag. In a POST request for a new push notification, a person would set a new field, "content," to the value of 1. This will be translated to "content-available" for the JSON sent to APNs.