### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the chat at https://gitter.im/airnotifier/airnotifier](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/airnotifier/airnotifier?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
-AirNotifier is an user friendly yet powerful application server for sending real-time notifications to mobile and desktop applications. AirNotifier provides an unified web service interface to deliver messages to multi devices using multi protocols, it also features a web based administrator UI to configure and manage services.
+AirNotifier is a user friendly yet powerful application server for sending real-time notifications to mobile and desktop applications. AirNotifier provides a unified web service interface to deliver messages to multi devices using multi protocols, it also features a web based administrator UI to configure and manage services.
 
 ## Supported devices
 - International SMS (uses [clickatell](https://www.clickatell.com/), credits required)


### PR DESCRIPTION
In the **Introduction** section of the README.md file there are 2 instances where article **"an"** has been used. It should be **"a"** as the next syllable following it is of the sound of a consonant.

Fixes #176 