### PR TITLE
Adding optional MongoDB authentication step

### DIFF
--- a/airnotifier.conf-sample
+++ b/airnotifier.conf-sample
@@ -17,3 +17,11 @@ masterdb = "airnotifier"
 collectionprefix = "obj_"
 dbprefix = ""
 appprefix = "app_"
+
+# If your MongoDB requires authentication, create a user with full permissions
+# to the masterdb and enter credentials here. For details, see:
+# https://docs.mongodb.com/manual/tutorial/enable-authentication/#procedure
+#
+# dbuser = "<your DB admin username>"
+# dbpass = "<your password>"
+# dbauthsource = "admin"

--- a/airnotifier.py
+++ b/airnotifier.py
@@ -63,6 +63,12 @@ define("collectionprefix", default="obj_", help="Collection name prefix")
 define("dbprefix", default="app_", help="DB name prefix")
 define("appprefix", default="", help="DB name prefix")
 
+# Database Authentication parameters
+define("dbuser", help="MongoDB admin user")
+define("dbpass", help="MongoDB admin password")
+define("dbauthsource", default="admin", help="MongoDB authentication source database")
+
+
 loggingconfigfile='logging.ini'
 if os.path.isfile(loggingconfigfile):
     logging.config.fileConfig(loggingconfigfile)
@@ -187,6 +193,10 @@ class AirNotifierApp(tornado.web.Application):
         self.mongodb = mongodb
 
         self.masterdb = mongodb[options.masterdb]
+        # Authenticate if credentials are supplied.
+        if options.dbuser is not None and options.dbpass is not None:
+            self.masterdb.authenticate(options.dbuser, options.dbpass, source=options.dbauthsource)
+
         assert self.masterdb.connection == self.mongodb
 
     def main(self):
@@ -225,6 +235,10 @@ def init_messaging_agents():
         except Exception as ex:
             _logger.error(ex)
     masterdb = mongodb[options.masterdb]
+    # Authenticate if credentials are supplied.
+    if options.dbuser is not None and options.dbpass is not None:
+        masterdb.authenticate(options.dbuser, options.dbpass, source=options.dbauthsource)
+
     apps = masterdb.applications.find()
     for app in apps:
         ''' APNs setup '''

--- a/install.py
+++ b/install.py
@@ -45,6 +45,11 @@ define("mongoport", default=27017, help="MongoDB port")
 define("mongodbname", default="airnotifier", help="MongoDB database name")
 define("masterdb", default="airnotifier", help="MongoDB DB to store information")
 
+# Database Authentication parameters
+define("dbuser", help="MongoDB admin user")
+define("dbpass", help="MongoDB admin password")
+define("dbauthsource", default="admin", help="MongoDB authentication source database")
+
 
 if __name__ == "__main__":
     if not path.exists("airnotifier.conf"):
@@ -54,6 +59,10 @@ if __name__ == "__main__":
     tornado.options.parse_command_line()
     mongodb = Connection(options.mongohost, options.mongoport)
     masterdb = mongodb[options.masterdb]
+    # Authenticate if credentials are supplied.
+    if options.dbuser is not None and options.dbpass is not None:
+        masterdb.authenticate(options.dbuser, options.dbpass, source=options.dbauthsource)
+
     collection_names = masterdb.collection_names()
     try:
         if not 'applications' in collection_names:

--- a/upgrade.py
+++ b/upgrade.py
@@ -45,6 +45,11 @@ define("masterdb", default="airnotifier", help="MongoDB DB to store information"
 define("collectionprefix", default="obj_", help="Collection name prefix")
 define("appprefix", default="", help="DB name prefix")
 
+# Database Authentication parameters
+define("dbuser", help="MongoDB admin user")
+define("dbpass", help="MongoDB admin password")
+define("dbauthsource", default="admin", help="MongoDB authentication source database")
+
 if __name__ == "__main__":
     curpath = os.path.dirname(os.path.realpath(__file__))
 
@@ -52,6 +57,10 @@ if __name__ == "__main__":
     tornado.options.parse_command_line()
     mongodb = Connection(options.mongohost, options.mongoport)
     masterdb = mongodb[options.masterdb]
+    # Authenticate if credentials are supplied.
+    if options.dbuser is not None and options.dbpass is not None:
+        masterdb.authenticate(options.dbuser, options.dbpass, source=options.dbauthsource)
+
     version_object = masterdb['options'].find_one({'name': 'version'})
     appprefix = options.appprefix
 


### PR DESCRIPTION
Added to `airnotifier.py`, `install.py`, `upgrade.py`.

To support better application security, this code will allow Airnotifier to authenticate as a user on a secured MongoDB database setup.

It's designed with fallbacks so that it will only attempt authentication when `airnotifier.conf` contains authentication details. Otherwise, it will continue without attempting authentication.

Sample/docs for config settings have been added to `airnotifier.conf-sample`.

Please let me know if there's anything you'd like me to amend.