### PR TITLE
app.py: Fix for mongodb authentication

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,12 +201,12 @@ class AirNotifierApp(tornado.web.Application):
                 error_log("Cannot not connect to MongoDB")
 
         self.mongodb = mongodb
+        self.masterdb = mongodb[options.masterdb]
         # Authenticate if credentials are supplied.
         if options.dbuser is not None and options.dbpass is not None:
             self.masterdb.authenticate(
                 options.dbuser, options.dbpass, source=options.dbauthsource
             )
-        self.masterdb = mongodb[options.masterdb]
 
     def main(self):
         if options.https:
@@ -238,12 +238,13 @@ def init_messaging_agents():
             mongodb = pymongo.MongoClient(options.mongohost, options.mongoport)
         except Exception as ex:
             _logger.error(ex)
+
+    masterdb = mongodb[options.masterdb]
     # Authenticate if credentials are supplied.
     if options.dbuser is not None and options.dbpass is not None:
         masterdb.authenticate(
             options.dbuser, options.dbpass, source=options.dbauthsource
         )
-    masterdb = mongodb[options.masterdb]
 
     apps = masterdb.applications.find()
     for app in apps:


### PR DESCRIPTION
In `app.py`, the code for optionally authenticating on the MongoDB master instance seems to have been merged in before the code that assigns a value to the `masterdb` variable.

The non-authenticating case would be unaffected, but I'm getting a `NameError: name 'masterdb' is not defined` when I try to run the app.

This change fixes the ordering.