### PR TITLE
fix broadcast for device_type_android and fcm

### DIFF
--- a/api/broadcast.py
+++ b/api/broadcast.py
@@ -44,7 +44,7 @@ from util import json_decode
 
 @route(r"/api/v2/broadcast[\/]?")
 class BroadcastHandler(APIBaseHandler):
-    def post(self):
+    async def post(self):
         if not self.can("send_broadcast"):
             self.send_response(FORBIDDEN, dict(error="No permission to send broadcast"))
             return
@@ -70,7 +70,7 @@ class BroadcastHandler(APIBaseHandler):
                 alert["title"] + ": " + alert["body"],
                 "important",
             )
-        self.application.send_broadcast(
+        await self.application.send_broadcast(
             self.appname,
             self.db,
             channel=channel,

--- a/web.py
+++ b/web.py
@@ -72,7 +72,7 @@ class WebApplication(tornado.web.Application):
 
         return {"msg": status, "error": error}
 
-    def send_broadcast(self, appname, appdb, **kwargs):
+    async def send_broadcast(self, appname, appdb, **kwargs):
         channel = kwargs.get("channel", "default")
         alert = kwargs.get("alert", None)
         sound = kwargs.get("sound", None)
@@ -117,8 +117,8 @@ class WebApplication(tornado.web.Application):
                             extra=extra,
                             apns=kwargs.get("apns", {}),
                         )
-                elif token["device"] == DEVICE_TYPE_FCM:
-                    fcm.process(
+                elif token["device"] == DEVICE_TYPE_FCM or token["device"] == DEVICE_TYPE_ANDROID:
+                    await fcm.process(
                         token=t, alert=alert, extra=extra, fcm=kwargs.get("fcm", {})
                     )
                 elif token["device"] == DEVICE_TYPE_WNS:


### PR DESCRIPTION
We're using the current master branch and had problems while broadcasting to Android devices.
Broadcasts would **not** be sent to Android devices.

Our Android devices token showed up as `"device": "android"` and I saw that DEVICE_TYPE_ANDROID was not handled in `web.py`'s `send_broadcast`.

I modified the condition and made the function `async`, since the `fcm.process` has to be awaited.

Now Broadcasting works for Android and iOS devices.