### PR TITLE
FIX: Duplicate "pemdir" definition in install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -50,7 +50,6 @@ define("pemdir", default="pemdir", help="Directory to store pems")
 define(
     "passwordsalt", default="d2o0n1g2s0h3e1n1g", help="Being used to make password hash"
 )
-define("pemdir", default="pemdir", help="Directory to store pems")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The duplicate "pemdir" definition causes the install-script to fail with:
```
tornado.options.Error: Option 'pemdir' already defined in ./install.py 
```
This PR removes the duplicate definition.